### PR TITLE
Check baseUrl var to avoid notice during cache generation

### DIFF
--- a/Imagine/CachePathResolver.php
+++ b/Imagine/CachePathResolver.php
@@ -52,7 +52,7 @@ class CachePathResolver
     {
         $path = $this->getBrowserPath($path, $filter);
 
-        if (0 === strpos($path, $this->baseUrl)) {
+        if (!empty($this->baseUrl) && 0 === strpos($path, $this->baseUrl)) {
             $path = $this->basePath.substr($path, strlen($this->baseUrl));
         }
 


### PR DESCRIPTION
A notice was thrown during cache generation : "strpos : empty delimiter", resulting in an incorrect picture content sent to the browser => images were not correctly displayed
