### PR TITLE
Add possibility to specify custom controller in configuration

### DIFF
--- a/Controller/ImagineController.php
+++ b/Controller/ImagineController.php
@@ -77,9 +77,10 @@ class ImagineController
      *
      * @return Response
      */
-    public function filter($path, $filter)
+    public function filter($path, $filter, $sourceDir = '')
     {
         $path = '/'.ltrim($path, '/');
+        if ($sourceDir != '') $sourceDir = '/'.ltrim($sourceDir, '/');
 
         //TODO: find out why I need double urldecode to get a valid path
         $browserPath = urldecode(urldecode($this->cachePathResolver->getBrowserPath($path, $filter)));
@@ -95,7 +96,7 @@ class ImagineController
         }
 
         $realPath = $this->webRoot.$browserPath;
-        $sourcePath = $this->webRoot.$path;
+        $sourcePath = $this->webRoot.$sourceDir.$path;
 
         // if the file has already been cached, we're probably not rewriting
         // correctly, hence make a 301 to proper location, so browser remembers

--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Each filter that you specify have the following options:
  - `type` - determine the type of filter to be used, refer to *Filters* section for more information
  - `options` - options that should be passed to the specific filter type
  - `path` - override the global `cache_prefix` and replace it with this path
+ - `controller` - override the default `imagine.controller:filter` controller with your own controller
 
 ## Built-in Filters
 

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ Each filter that you specify have the following options:
  - `options` - options that should be passed to the specific filter type
  - `path` - override the global `cache_prefix` and replace it with this path
  - `controller` - override the default `imagine.controller:filter` controller with your own controller
+ - `sourceDir` - default directory for source images. Relative path provided for apply_filter is related to this directory
 
 ## Built-in Filters
 

--- a/Routing/ImagineLoader.php
+++ b/Routing/ImagineLoader.php
@@ -40,6 +40,9 @@ class ImagineLoader extends Loader
                 if (isset($options['controller'])) {
                     $defaults['_controller'] = $options['controller'];
                 }
+                if (isset($options['sourceDir'])) {
+                    $defaults['sourceDir'] = $options['sourceDir'];
+                }
                 
                 $routes->add('_imagine_'.$filter, new Route(
                     $pattern,

--- a/Routing/ImagineLoader.php
+++ b/Routing/ImagineLoader.php
@@ -36,10 +36,14 @@ class ImagineLoader extends Loader
                 } else {
                     $pattern = '/'.trim($this->cachePrefix, '/').'/'.$filter.'/{path}';
                 }
-
+                $defaults['filter'] = $filter;
+                if (isset($options['controller'])) {
+                    $defaults['_controller'] = $options['controller'];
+                }
+                
                 $routes->add('_imagine_'.$filter, new Route(
                     $pattern,
-                    array_merge( $defaults, array('filter' => $filter)),
+                    $defaults,
                     $requirements
                 ));
             }


### PR DESCRIPTION
This function allows user to use customized controller for rendering of an image. This is useful for example when the user wants to use different cachePathResolver.

Simple example:

```
avalanche_imagine:
    filters:
        my_filter:
            type:    thumbnail
            options: { size: [574, 260], mode: outbound }
            controller: my_company.my_image_controller:filter
```

services.yml:

```
my_company.my_image_controller:
    class: %imagine.controller.class%
    scope: request
    arguments:
        - @request
        - @my_company.my_cachepath_resolver
        - @imagine
        - @imagine.filter.manager
        - @filesystem
        - %imagine.web_root%
```
