### PR TITLE
Add parameter sourceDir to filter

### DIFF
--- a/Controller/ImagineController.php
+++ b/Controller/ImagineController.php
@@ -77,9 +77,10 @@ class ImagineController
      *
      * @return Response
      */
-    public function filter($path, $filter)
+    public function filter($path, $filter, $sourceDir = '')
     {
         $path = '/'.ltrim($path, '/');
+		if ($sourceDir != '') $sourceDir = '/'.ltrim($sourceDir, '/');
 
         //TODO: find out why I need double urldecode to get a valid path
         $browserPath = urldecode(urldecode($this->cachePathResolver->getBrowserPath($path, $filter)));
@@ -95,7 +96,7 @@ class ImagineController
         }
 
         $realPath = $this->webRoot.$browserPath;
-        $sourcePath = $this->webRoot.$path;
+        $sourcePath = $this->webRoot.$sourceDir.$path;
 
         // if the file has already been cached, we're probably not rewriting
         // correctly, hence make a 301 to proper location, so browser remembers

--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Each filter that you specify have the following options:
  - `type` - determine the type of filter to be used, refer to *Filters* section for more information
  - `options` - options that should be passed to the specific filter type
  - `path` - override the global `cache_prefix` and replace it with this path
+ - `sourceDir` - default directory for source images. Relative path provided for apply_filter is related to this directory
 
 ## Built-in Filters
 

--- a/Routing/ImagineLoader.php
+++ b/Routing/ImagineLoader.php
@@ -35,11 +35,15 @@ class ImagineLoader extends Loader
                     $pattern = '/'.trim($options['path'], '/').'/{path}';
                 } else {
                     $pattern = '/'.trim($this->cachePrefix, '/').'/'.$filter.'/{path}';
+                }				
+				$defaults['filter'] = $filter;
+                if (isset($options['sourceDir'])) {
+                    $defaults['sourceDir'] = $options['sourceDir'];
                 }
 
                 $routes->add('_imagine_'.$filter, new Route(
                     $pattern,
-                    array_merge( $defaults, array('filter' => $filter)),
+                    $defaults,
                     $requirements
                 ));
             }


### PR DESCRIPTION
I have added one more parameter to a filter.
Some filters are used only for one folder (and perhaps subfolders) of images. New option sourceDir allows user to specify this directory. Than, the relative path for apply_filter is not related to web_root but to the sourceDir direcotory.

Example: image is located in 

```
web/images/cars/models/skoda-octavia.jpg
```

imagine settings:

```
avalanche_imagine:
    filters:
        car_model:
            type:    thumbnail
            options: { size: [574, 260], mode: outbound }
            sourceDir: images/cars/models
```

Twig usage:

```
{{ 'skoda-octavia.jpg'|apply_filter('car_model') }}
```
