### PR TITLE
Generate absolute URL for images with ImagineHelper

### DIFF
--- a/Imagine/CachePathResolver.php
+++ b/Imagine/CachePathResolver.php
@@ -34,8 +34,9 @@ class CachePathResolver
      *
      * @param string $path
      * @param string $filter
+     * @param boolean $absolute
      */
-    public function getBrowserPath($path, $filter)
+    public function getBrowserPath($path, $filter, $absolute = false)
     {
         // identify if current path is not under specified web root and return
         // unmodified path in that case
@@ -50,7 +51,7 @@ class CachePathResolver
             urldecode(ltrim($path, '/')),
             $this->router->generate('_imagine_'.$filter, array(
                 'path' => ltrim($path, '/')
-            ))
+            ),$absolute)
         );
 
         return $path;

--- a/Templating/Helper/ImagineHelper.php
+++ b/Templating/Helper/ImagineHelper.php
@@ -27,12 +27,13 @@ class ImagineHelper extends Helper
      *
      * @param string $path
      * @param string $filter
-     *
+     * @param boolean $absolute
+     * 
      * @return string
      */
-    public function filter($path, $filter)
+    public function filter($path, $filter, $absolute = false)
     {
-        return $this->cachePathResolver->getBrowserPath($path, $filter);
+        return $this->cachePathResolver->getBrowserPath($path, $filter, $absolute);
     }
 
     /**


### PR DESCRIPTION
might be useful to allow absolute URL generating since UrlGeneratorInterface::generate allows it. 
