### PR TITLE
Separate image source

### DIFF
--- a/Controller/ImagineController.php
+++ b/Controller/ImagineController.php
@@ -42,6 +42,8 @@ class ImagineController
      */
     private $webRoot;
 
+    private $sourceRoot;
+
     /**
      * Constructs by setting $cachePathResolver
      *
@@ -58,7 +60,8 @@ class ImagineController
         ImagineInterface $imagine,
         FilterManager $filterManager,
         Filesystem $filesystem,
-        $webRoot
+        $webRoot,
+        $sourceRoot
     )
     {
         $this->request           = $request;
@@ -67,6 +70,7 @@ class ImagineController
         $this->filterManager     = $filterManager;
         $this->filesystem        = $filesystem;
         $this->webRoot           = $webRoot;
+        $this->sourceRoot        = $sourceRoot;
     }
 
     /**
@@ -96,7 +100,7 @@ class ImagineController
         }
 
         $realPath = $this->webRoot.$browserPath;
-        $sourcePath = $this->webRoot.$path;
+        $sourcePath = $this->sourceRoot.$path;
 
         // if the file has already been cached, we're probably not rewriting
         // correctly, hence make a 301 to proper location, so browser remembers

--- a/DependencyInjection/AvalancheImagineExtension.php
+++ b/DependencyInjection/AvalancheImagineExtension.php
@@ -32,7 +32,7 @@ class AvalancheImagineExtension extends Extension
 
         $container->setAlias('imagine', new Alias('imagine.'.$driver));
 
-        foreach (array('cache_prefix', 'web_root', 'filters') as $key) {
+        foreach (array('cache_prefix', 'web_root', 'source_root', 'filters') as $key) {
             if (isset($config[$key])) {
                 $container->setParameter('imagine.'.$key, $config[$key]);
             }

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ The default configuration for the bundle looks like this:
 
 ``` yaml
 avalanche_imagine:
+    source_root:  %kernel.root_dir%/../web
     web_root:     %kernel.root_dir%/../web
     cache_prefix: media/cache
     driver:       gd
@@ -162,6 +163,14 @@ avalanche_imagine:
 ```
 
 There are several configuration options available:
+
+ - `source_root` - can be set to the absolute path to your original image's
+    directory. This option allows you to store the original image in a 
+    different location from the web root. Under this root the images will 
+    be looked for in the same relative path specified in the apply_filter
+    template filter.
+
+    default: `%kernel.root_dir%/../web`
 
  - `web_root` - must be the absolute path to you application's web root. This
     is used to determine where to put generated image files, so that apache

--- a/Resources/config/imagine.xml
+++ b/Resources/config/imagine.xml
@@ -8,6 +8,7 @@
         <!-- Configuration defaults -->
 
         <parameter key="imagine.web_root">%kernel.root_dir%/../web</parameter>
+        <parameter key="imagine.source_root">%kernel.root_dir%/../web</parameter>
         <parameter key="imagine.cache_prefix">media/cache</parameter>
         <parameter key="imagine.filters" type="collection" />
 
@@ -63,6 +64,7 @@
             <argument type="service" id="imagine.filter.manager" />
             <argument type="service" id="filesystem" />
             <argument>%imagine.web_root%</argument>
+            <argument>%imagine.source_root%</argument>
         </service>
 
         <!-- Route Loader -->


### PR DESCRIPTION
I needed this for my project and I found it might be useful for others. I needed to have the original images uploaded to app/Resources/originals (not in the web/ directory - where others can access them), so I just made a few basic changes. I hope I did it right, and if you want to pull the changes, I'll try to update the docs accordingly, just let me know.
