### PR TITLE
Fixed exception thrown when applying a new filter for first time

### DIFF
--- a/Controller/ImagineController.php
+++ b/Controller/ImagineController.php
@@ -119,7 +119,7 @@ class ImagineController
         $dir = pathinfo($realPath, PATHINFO_DIRNAME);
 
         if (!is_dir($dir)) {
-            if (!$this->filesystem->mkdir($dir)) {
+            if (false === $this->filesystem->mkdir($dir)) {
                 throw new \RuntimeException(sprintf(
                     'Could not create directory %s', $dir
                 ));


### PR DESCRIPTION
An exception was thrown when creating a new directory in media/cache after applying a new filter for the first time - exception only thrown when using Symfony 2.1
