### PR TITLE
Use format as default format

### DIFF
--- a/Controller/ImagineController.php
+++ b/Controller/ImagineController.php
@@ -131,7 +131,9 @@ class ImagineController
             // TODO: get rid of hard-coded quality and format
             $this->filterManager->get($filter)
                 ->apply($this->imagine->open($sourcePath))
-                ->save($realPath, array('quality' => $this->filterManager->getOption($filter, "quality", 100)))
+                ->save($realPath, array(
+                    'quality' => $this->filterManager->getOption($filter, "quality", 100)),
+                    'format' => $this->filterManager->getOption($filter, "format", ""))
                 ->show($this->filterManager->getOption($filter, "format", "png"));
 
             // TODO: add more media headers

--- a/Controller/ImagineController.php
+++ b/Controller/ImagineController.php
@@ -133,7 +133,7 @@ class ImagineController
                 ->apply($this->imagine->open($sourcePath))
                 ->save($realPath, array(
                     'quality' => $this->filterManager->getOption($filter, "quality", 100)),
-                    'format' => $this->filterManager->getOption($filter, "format", ""))
+                    'format' => $this->filterManager->getOption($filter, "format", null))
                 ->show($this->filterManager->getOption($filter, "format", "png"));
 
             // TODO: add more media headers


### PR DESCRIPTION
Use format form options as format if the format cannot be infered from the filename.
