### PR TITLE
allow applying multiple filters to an image

### DIFF
--- a/Controller/ImagineController.php
+++ b/Controller/ImagineController.php
@@ -128,10 +128,14 @@ class ImagineController
 
         ob_start();
         try {
+            $filters = explode('.', $filter);
+            $image = $this->imagine->open($sourcePath);
+            foreach ($filters as $filter) {
+                $image = $this->filterManager->get($filter)
+                    ->apply($image);
+            }
             // TODO: get rid of hard-coded quality and format
-            $this->filterManager->get($filter)
-                ->apply($this->imagine->open($sourcePath))
-                ->save($realPath, array('quality' => $this->filterManager->getOption($filter, "quality", 100)))
+            $image->save($realPath, array('quality' => $this->filterManager->getOption($filter, "quality", 100)))
                 ->show($this->filterManager->getOption($filter, "format", "png"));
 
             // TODO: add more media headers

--- a/Imagine/CachePathResolver.php
+++ b/Imagine/CachePathResolver.php
@@ -46,12 +46,18 @@ class CachePathResolver
             return $path;
         }
 
+        $url = $this->router->getRouteCollection()->get('_imagine_'.$filter) ?
+            $this->router->generate('_imagine_'.$filter, array(
+                'path' => ltrim($path, '/')
+            ),$absolute) :
+            $this->router->generate('_imagine', array(
+                'filter' => $filter,
+                'path' => ltrim($path, '/')
+            ),$absolute);
         $path = str_replace(
             urlencode(ltrim($path, '/')),
             urldecode(ltrim($path, '/')),
-            $this->router->generate('_imagine_'.$filter, array(
-                'path' => ltrim($path, '/')
-            ),$absolute)
+            $url
         );
 
         return $path;

--- a/README.md
+++ b/README.md
@@ -154,6 +154,13 @@ Or if you're using PHP templates:
 <img src="<?php $this['imagine']->filter('/relative/path/to/image.jpg', 'my_thumb') ?>" />
 ```
 
+It's also possible to apply multiple filters by passing additional arguments
+(for example to make a thumbnail and rotate it):
+
+``` jinja
+<img src="{{ '/relative/path/to/image.jpg' | apply_filter('my_thumb', 'my_other_filter') }}" />
+```
+
 Behind the scenes, the bundle applies the filter(s) to the image on the first
 request and then caches the image to a similar path. On the next request,
 the cached image would be served directly from the file system.
@@ -208,7 +215,7 @@ Each filter that you specify have the following options:
 
  - `type` - determine the type of filter to be used, refer to *Filters* section for more information
  - `options` - options that should be passed to the specific filter type
- - `path` - override the global `cache_prefix` and replace it with this path
+ - `path` - override the global `cache_prefix` and replace it with this path (this option is not compatible with applying multiple filters)
 
 ## Built-in Filters
 

--- a/Routing/ImagineLoader.php
+++ b/Routing/ImagineLoader.php
@@ -25,23 +25,29 @@ class ImagineLoader extends Loader
 
     public function load($resource, $type = null)
     {
-        $requirements = array('_method' => 'GET', 'filter'  => '[A-z0-9_\-]*', 'path'    => '.+');
+        $requirements = array('_method' => 'GET', 'filter'  => '[A-Za-z0-9_\-\.]*', 'path'    => '.+');
         $defaults     = array('_controller' => 'imagine.controller:filter');
         $routes       = new RouteCollection();
 
+        $genericRouteAdded = false;
         if (count($this->filters) > 0) {
             foreach ($this->filters as $filter => $options) {
                 if (isset($options['path'])) {
                     $pattern = '/'.trim($options['path'], '/').'/{path}';
-                } else {
-                    $pattern = '/'.trim($this->cachePrefix, '/').'/'.$filter.'/{path}';
+                    $routes->add('_imagine_'.$filter, new Route(
+                        $pattern,
+                        array_merge( $defaults, array('filter' => $filter)),
+                        $requirements
+                    ));
+                } else if (!$genericRouteAdded) {
+                    $pattern = '/'.trim($this->cachePrefix, '/').'/{filter}/{path}';
+                    $routes->add('_imagine', new Route(
+                        $pattern,
+                        $defaults,
+                        $requirements
+                    ));
+                    $genericRouteAdded = true;
                 }
-
-                $routes->add('_imagine_'.$filter, new Route(
-                    $pattern,
-                    array_merge( $defaults, array('filter' => $filter)),
-                    $requirements
-                ));
             }
         }
 

--- a/Templating/ImagineExtension.php
+++ b/Templating/ImagineExtension.php
@@ -42,8 +42,17 @@ class ImagineExtension extends \Twig_Extension
      *
      * @return string
      */
-    public function applyFilter($path, $filter, $absolute = false)
+    public function applyFilter()
     {
+        $args = func_get_args();
+        $path = array_shift($args);
+        if (is_bool(end($args))) {
+            $absolute = array_pop($args);
+        }
+        else {
+            $absolute = false;
+        }
+        $filter = implode('.', $args);
         return $this->cachePathResolver->getBrowserPath($path, $filter, $absolute);
     }
 


### PR DESCRIPTION
Does something like this seem reasonable for handling chaining filters? The "filter" in the URL would be a list of filter names joined by some character that does not occur in filter names (I used dots), and `apply_filter()` would accept multiple arguments. The only problem is handling filters that use the `path` option, but I think a lot of people would give up the `path` option to get the ability to chain filters—for example, to make a thumbnail and rotate it.
