### PR TITLE
Added PasteFilterLoader

### DIFF
--- a/Imagine/Filter/Loader/PasteFilterLoader.php
+++ b/Imagine/Filter/Loader/PasteFilterLoader.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Liip\ImagineBundle\Imagine\Filter\Loader;
+
+use Imagine\Image\Point;
+use Imagine\Filter\Basic\Paste;
+use Imagine\Image\ImageInterface;
+use Imagine\Image\ImagineInterface;
+
+class PasteFilterLoader implements LoaderInterface
+{
+    public function __construct(ImagineInterface $imagine, $rootPath)
+    {
+        $this->imagine = $imagine;
+        $this->rootPath = $rootPath;
+    }
+
+    public function load(ImageInterface $image, array $options = array())
+    {
+        list($x, $y) = $options['start'];
+        $destImage = $this->imagine->open($this->rootPath.'/../'.$options['image']);
+
+        $filter = new Paste($destImage, new Point($x, $y));
+        $image = $filter->apply($image);
+
+        return $image;
+    }
+}

--- a/Resources/config/imagine.xml
+++ b/Resources/config/imagine.xml
@@ -39,6 +39,7 @@
         <!-- Filter loaders' classes -->
 
         <parameter key="imagine.filter.loader.thumbnail.class">Avalanche\Bundle\ImagineBundle\Imagine\Filter\Loader\ThumbnailFilterLoader</parameter>
+        <parameter key="liip_imagine.filter.loader.paste.class">Liip\ImagineBundle\Imagine\Filter\Loader\PasteFilterLoader</parameter>
 
     </parameters>
 
@@ -101,6 +102,12 @@
 
         <service id="imagine.filter.loader.thumbnail" class="%imagine.filter.loader.thumbnail.class%">
             <tag name="imagine.filter.loader" filter="thumbnail" />
+        </service>
+
+        <service id="liip_imagine.filter.loader.paste" class="%liip_imagine.filter.loader.paste.class%">
+            <tag name="liip_imagine.filter.loader" loader="paste" />
+            <argument type="service" id="liip_imagine" />
+            <argument>%kernel.root_dir%</argument>
         </service>
 
     </services>


### PR DESCRIPTION
Added a filter loader for the 'Paste' filter. I really think there ought to be loaders for all the in-built Imagine filters so everything works out the box.

Example configuration for adding a watermark to an image:

```
liip_imagine:
    filter_sets:
        product_image:
            quality: 90
            filters:
                paste: { start: [577, 375], image: web/img/watermark.png }
```

P.S. bundle is a life-saver! Thx!
