### PR TITLE
Updated composer workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Add AvalancheImagineBundle in your composer.json:
 ```js
 {
     "require": {
-        "avalanche123/imagine-bundle": "*"
+        "avalanche123/imagine-bundle": "v2.1"
     }
 }
 ```

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,13 @@
     "homepage": "https://github.com/avalanche123/AvalancheImagineBundle",
     "type": "symfony-bundle",
     "license": "MIT",
+    "repositories":[
+        {
+            "type":"git",
+            "url":"git://github.com/avalanche123/Imagine.git"
+        }
+    ],
+
     "authors": [
         {
             "name": "Bulat Shakirzyanov",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "symfony/framework-bundle": "2.*",
-        "imagine/Imagine": "dev-master"
+        "imagine/Imagine": "v2.1"
     },
     "suggest": {
         "symfony/twig-bundle": "2.*"


### PR DESCRIPTION
I have error **The requested package avalanche123/imagine-bundle could not be found in any version, there may be a typo in the package name.** when I add to composer.json 

<pre>
    "require": {
        "avalanche123/imagine-bundle": "*"
    }
</pre>

If I change "_" to "master-dev" error is 
  *_\- Installation request for avalanche123/imagine-bundle master-dev -> satisfiable by avalanche123/imagine-bundle dev-master.
    - avalanche123/imagine-bundle dev-master requires imagine/imagine dev-master -> no matching package found.**

composer did not find imagine/imagine package and I have to add code to my composer.json like:

<pre>
    "repositories":[
        {
            "type":"git",
            "url":"git://github.com/avalanche123/Imagine.git"
        }
    ],
    "require":{
        "imagine/Imagine": "dev-master",
        "avalanche123/imagine-bundle": "master-dev"
    }
</pre>


Using dev version of the library in production project is actually bad idea, but tag symfony-2.0 cant be used by composer. If I try to use code

<pre>
"avalanche123/imagine-bundle": "symfony-2.0"
</pre>

I got error
**[UnexpectedValueException]
  Could not parse version constraint symfony-2.0**

So, I have such a suggestions
1) add repository section to the  avalanche123 / AvalancheImagineBundle composer.json, because composer cant find imagine/imagine
2) add tags **v2.1** to the  avalanche123 / AvalancheImagineBundle and Imagine/Imagine
3) update composer.json file to use v2.1 tag
4) update installation instructions to use v2.1 instead

All updates (except tag v2.1 for both bundles) included in this PR
