### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Add AvalancheImagineBundle in your composer.json:
 ```js
 {
     "require": {
-        "avalanche123/imagine-bundle": "v2.1"
+        "avalanche123/imagine-bundle": "dev-master"
     }
 }
 ```


### PR DESCRIPTION
If you install the bundle via composer in v2.1, only the thumbnail filter will work, the rest is not added. Since only the thumbnail filter works, the documentation is too extended and wrong.
