### PR TITLE
Return null when original file doesn't exist

### DIFF
--- a/Imagine/CachePathResolver.php
+++ b/Imagine/CachePathResolver.php
@@ -41,6 +41,9 @@ class CachePathResolver
         // identify if current path is not under specified web root and return
         // unmodified path in that case
         $realPath = realpath($this->webRoot.$path);
+        if (!is_file($realPath)) {
+            return null;
+        }
 
         if (!0 === strpos($realPath, $this->webRoot)) {
             return $path;


### PR DESCRIPTION
It is hard to manage images that are optional.
So is not it better to return null when original file doesn't exist.
It allows us to write something like `{{ entity.getImage | apply_filter('some') | default('placeholder.img') }}`.
