### PR TITLE
Assetic support for ImagineBundle

### DIFF
--- a/Assetic/Filter/ImagineFilter.php
+++ b/Assetic/Filter/ImagineFilter.php
@@ -1,0 +1,88 @@
+<?php
+namespace Avalanche\Bundle\ImagineBundle\Assetic\Filter;
+
+use Assetic\Asset\AssetInterface;
+use Assetic\Asset\FileAsset;
+use Assetic\AssetManager;
+use Assetic\AssetWriter;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Assetic\Factory\AssetFactory;
+use Assetic\Factory\Resource\FileResource;
+use Symfony\Component\Routing\RouterInterface;
+use Imagine\Image\ImagineInterface;
+use Avalanche\Bundle\ImagineBundle\Imagine\Filter\FilterManager;
+use Assetic\Filter\FilterInterface;
+
+/**
+ * The Filter itself
+ */
+class ImagineFilter implements FilterInterface
+{
+    /**
+     * @var ImagineInterface
+     */
+    private $imagine;
+
+    /**
+     * @var FilterManager
+     */
+    private $filterManager;
+
+    /**
+     * @var string
+     */
+    private $imagineFilter;
+
+    /**
+     * Constructor.
+     *
+     * @param ImagineInterface $imagine       Imagine
+     * @param FilterManager    $filterManager Imagine Filter Manager
+     *
+     * @return ImagineFilter
+     */
+    public function __construct(ImagineInterface $imagine, FilterManager $filterManager, $imagineFilter)
+    {
+        $this->imagine = $imagine;
+        $this->filterManager = $filterManager;
+        $this->imagineFilter = $imagineFilter;
+    }
+
+    /**
+     * Not in use
+     *
+     * @param AssetInterface $asset The asset
+     *
+     * @return void
+     */
+    public function filterLoad(AssetInterface $asset)
+    {
+    }
+
+    /**
+     * Main logic is located here.
+     * We parse the css here and create for all matching images a seperate asset
+     *
+     * @param AssetInterface $asset The asset
+     *
+     * @return void
+     */
+    public function filterDump(AssetInterface $asset)
+    {
+        ob_start();
+        try {
+            $format  = $this->filterManager->getOption($this->imagineFilter, "format", "png");
+
+            $this->filterManager->getFilter($this->imagineFilter)
+                ->apply($this->imagine->load($asset->getContent()))
+                ->show($format);
+
+            $asset->setContent(ob_get_clean());
+            ob_end_clean();
+        } catch (\Exception $e) {
+            ob_end_clean();
+            throw $e;
+        }
+    }
+}

--- a/Assetic/Filter/ImagineFilter.php
+++ b/Assetic/Filter/ImagineFilter.php
@@ -79,9 +79,8 @@ class ImagineFilter implements FilterInterface
                 ->show($format);
 
             $asset->setContent(ob_get_clean());
-            ob_end_clean();
         } catch (\Exception $e) {
-            ob_end_clean();
+            @ob_end_clean();
             throw $e;
         }
     }

--- a/AvalancheImagineBundle.php
+++ b/AvalancheImagineBundle.php
@@ -3,6 +3,7 @@
 namespace Avalanche\Bundle\ImagineBundle;
 
 use Avalanche\Bundle\ImagineBundle\DependencyInjection\Compiler\LoadersCompilerPass;
+use Avalanche\Bundle\ImagineBundle\DependencyInjection\Compiler\AsseticCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -16,5 +17,6 @@ class AvalancheImagineBundle extends Bundle
         parent::build($container);
 
         $container->addCompilerPass(new LoadersCompilerPass());
+        $container->addCompilerPass(new AsseticCompilerPass());
     }
 }

--- a/DependencyInjection/Compiler/AsseticCompilerPass.php
+++ b/DependencyInjection/Compiler/AsseticCompilerPass.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Avalanche\Bundle\ImagineBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\DefinitionDecorator;
+
+class AsseticCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('assetic.filter_manager')) {
+            return;
+        }
+
+        $filters = $container->getParameter('imagine.filters');
+        $asseticFilterManagerDef = $container->getDefinition('assetic.filter_manager');
+        foreach($filters as $name => $options) {
+            $filterName = 'imagine_' . $name;
+            $filterClass = new DefinitionDecorator('imagine.assetic.filter');
+            $filterClass->replaceArgument(2, $name);
+            $container->setDefinition('imagine.assetic.filter.' . $filterName, $filterClass);
+            $asseticFilterManagerDef->addMethodCall('set', array($filterName, new Reference('imagine.assetic.filter.' . $filterName)));
+        }
+    }
+}

--- a/DependencyInjection/Compiler/AsseticCompilerPass.php
+++ b/DependencyInjection/Compiler/AsseticCompilerPass.php
@@ -18,11 +18,13 @@ class AsseticCompilerPass implements CompilerPassInterface
         $filters = $container->getParameter('imagine.filters');
         $asseticFilterManagerDef = $container->getDefinition('assetic.filter_manager');
         foreach($filters as $name => $options) {
-            $filterName = 'imagine_' . $name;
-            $filterClass = new DefinitionDecorator('imagine.assetic.filter');
-            $filterClass->replaceArgument(2, $name);
-            $container->setDefinition('imagine.assetic.filter.' . $filterName, $filterClass);
-            $asseticFilterManagerDef->addMethodCall('set', array($filterName, new Reference('imagine.assetic.filter.' . $filterName)));
+            if (isset($options['options']) && isset($options['options']['assetic']) && ((bool) $options['options']['assetic'] === true )) {
+                $filterName = 'imagine_' . $name;
+                $filterClass = new DefinitionDecorator('imagine.assetic.filter');
+                $filterClass->replaceArgument(2, $name);
+                $container->setDefinition('imagine.assetic.filter.' . $filterName, $filterClass);
+                $asseticFilterManagerDef->addMethodCall('set', array($filterName, new Reference('imagine.assetic.filter.' . $filterName)));
+            }
         }
     }
 }

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2004-2013 Bulat Shakirzyanov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -370,3 +370,20 @@ Then, call the getBrowserPath and pass the original image webpath and the filter
 ```php
 $cachedImage = $avalancheService->getBrowserPath($object->getWebPath(), 'my_thumb');
 ```
+
+## Using in combination with assetic
+
+If you want to render static images with assetic, but want to leverage the image manipulation features
+of imagine you can enable on a per filter basis assetic support.
+
+``` yaml
+filters:
+    filtername:
+        options: { assetic: true }
+```
+
+If you enable assetic for a filter the filter will be available as an assetic filter with the imagine filters name,
+prefixed by "imagine_" as in our example "imagine_filtername".
+
+Assetic has some name restriction this restriction apply here too, which means, the filtername
+can only contain A-Z, 0-9 and underscores. This affects only filters with enabled assetic support.

--- a/Resources/config/imagine.xml
+++ b/Resources/config/imagine.xml
@@ -12,6 +12,9 @@
         <parameter key="imagine.cache_prefix">media/cache</parameter>
         <parameter key="imagine.filters" type="collection" />
 
+        <!-- Assetic classes -->
+        <parameter key="imagine.assetic.filter.class">Avalanche\Bundle\ImagineBundle\Assetic\Filter\ImagineFilter</parameter>
+
         <!-- Utility classes -->
 
         <parameter key="imagine.filter.manager.class">Avalanche\Bundle\ImagineBundle\Imagine\Filter\FilterManager</parameter>
@@ -52,7 +55,14 @@
     </parameters>
 
     <services>
-        
+
+        <!-- Assetic service -->
+        <service id="imagine.assetic.filter" class="%imagine.assetic.filter.class%" abstract="true">
+            <argument type="service" id="imagine" />
+            <argument type="service" id="imagine.filter.manager" />
+            <argument/>
+        </service>
+
         <!-- Utility services -->
 
         <service id="imagine.cache.path.resolver" class="%imagine.cache.path.resolver.class%">


### PR DESCRIPTION
This pull request adds assetic support for the ImagineBundle.

You now can enable on a per filter basis if you want to use this filter with assetic aswell.

This pull request also closes #141
