### PR TITLE
Check if $cached is not a directory to avoid error on unlink

### DIFF
--- a/Imagine/CachePathResolver.php
+++ b/Imagine/CachePathResolver.php
@@ -56,7 +56,7 @@ class CachePathResolver
         
         $cached = realpath($this->webRoot.$path);
 
-        if (file_exists($cached) && filemtime($realPath) > filemtime($cached)) {
+        if (file_exists($cached) && !is_dir($cached) && filemtime($realPath) > filemtime($cached)) {
             unlink($cached);
         }
 


### PR DESCRIPTION
Since the CachePathResolver is unlinking file, is it possible to check first that the $cached is a file, not a directory, to avoid error on trying to unlink a directory ? 

cf https://github.com/avalanche123/AvalancheImagineBundle/issues/134
