### PR TITLE
Merge recursively the config

### DIFF
--- a/DependencyInjection/AvalancheImagineExtension.php
+++ b/DependencyInjection/AvalancheImagineExtension.php
@@ -44,7 +44,7 @@ class AvalancheImagineExtension extends Extension
         $config = array();
 
         foreach ($configs as $cnf) {
-            $config = array_merge($config, $cnf);
+            $config = array_merge_recursive($config, $cnf);
         }
 
         return $config;


### PR DESCRIPTION
When more than one bundle extension implement the PrependExtensionInterface to define different filter, only one is kept by the array_merge method. With array_merge_recursive,  it will kept filters defined by each bundle. 
