### PR TITLE
Array replace recursively the configuration

### DIFF
--- a/DependencyInjection/AvalancheImagineExtension.php
+++ b/DependencyInjection/AvalancheImagineExtension.php
@@ -44,7 +44,7 @@ class AvalancheImagineExtension extends Extension
         $config = array();
 
         foreach ($configs as $cnf) {
-            $config = array_merge($config, $cnf);
+            $config = array_replace_recursive($config, $cnf);
         }
 
         return $config;


### PR DESCRIPTION
This allows multiple bundles to configure and override default filters / config values without losing predefined data or appending values to numerical arrays ('size' within filters options)
