### PR TITLE
Fixing bug when verifying cached content + concurrency related issue.

### DIFF
--- a/Imagine/CacheManager.php
+++ b/Imagine/CacheManager.php
@@ -65,11 +65,11 @@ class CacheManager
         $sourcePath = $this->sourceRoot.$path;
 
         // if the file has already been cached, just return path
-        if (file_exists($realPath)) {
+        if (is_file($realPath)) {
             return $realPath;
         }
 
-        if (!file_exists($sourcePath)) {
+        if (!is_file($sourcePath)) {
             return null;
         }
 

--- a/Imagine/CacheManager.php
+++ b/Imagine/CacheManager.php
@@ -76,10 +76,16 @@ class CacheManager
         $dir = pathinfo($realPath, PATHINFO_DIRNAME);
 
         if (!is_dir($dir)) {
-            if (false === $this->filesystem->mkdir($dir)) {
-                throw new \RuntimeException(sprintf(
-                    'Could not create directory %s', $dir
-                ));
+            try {
+                if (false === $this->filesystem->mkdir($dir)) {
+                    throw new \RuntimeException(sprintf(
+                        'Could not create directory %s', $dir
+                    ));
+                }
+            } catch (\Exception $e) {
+                if (!is_dir($dir)) {
+                    throw $e;
+                }
             }
         }
 


### PR DESCRIPTION
## 1 Cached content dir

When accessing directly an URL with a dir inside a cached directory (like `/media/cache/offer/media/` for `/media/cache/offer/media/thumb-image.jpg`) the response returns with a 500 code. After changing the using of `file_exists` by `is_file` function, to check if the path realy contains a file, the response return with a 404 code, that is "more" correct.
## 2 Concurrency

There is a PHP bug (https://bugs.php.net/bug.php?id=35326) related to recursive directory creation and concurrency. When calling the ImagineController with paralel requests, this bug is achieved, throwing an exception. To fix it, I added a second check for directory existence before throw the exception.
