### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,18 +26,8 @@ Installation is a quick 3 step process:
 
 Add AvalancheImagineBundle in your composer.json:
 
-```js
-{
-    "require": {
-        "avalanche123/imagine-bundle": "v2.1"
-    }
-}
-```
-
-Now tell composer to download the bundle by running the command:
-
-``` bash
-$ php composer.phar update avalanche123/imagine-bundle
+```sh
+composer require avalanche123/imagine-bundle
 ```
 
 Composer will install the bundle to your project's `vendor/avalanche123/imagine-bundle` directory.


### PR DESCRIPTION
Updated installation instructions via composer to use the `composer require` command without specifying a version.
This is the new recommended way of providing this information and it leads to composer picking the proper version constraint (i.e ~1.2), updating the `composer.json` and running install, all in one command.
