### PR TITLE
Fixing cached asset path for dev mode

### DIFF
--- a/Imagine/CachePathResolver.php
+++ b/Imagine/CachePathResolver.php
@@ -61,6 +61,9 @@ class CachePathResolver
             ), $absolute)
         );
         
+        // removing any files in the path, eg app_dev.php
+        $path = preg_replace('/\/[^\/\.]*\.php\//', '/', $path);
+        
         $cached = realpath($this->webRoot.$path);
 
         if (file_exists($cached) && !is_dir($cached) && filemtime($realPath) > filemtime($cached)) {


### PR DESCRIPTION
This is still not fixed in the latest commit 8ee4e5fd29bc02d1cffea800eabca31b0c6be0fa although it was close...

The problem is that in dev mode the URL generated by the `router->generate()` contains "app_dev.php" so the URL can never be directly converted to a file path.

eg. the `$cached` file path is `/var/www/site/app/../web/app_dev.php/media/cache/background/uploads/Big_dipper.png` so the line
`file_exists($cached)` doesn't exist

This will affect any user of this bundle who uses `app_dev.php` in the URL of their dev environment (which I think is the majority) and the images will always be regenerated and never loaded from cache. On pages with a lot of generated images this was taking a long time to load.

This fix will make sure that the app_dev.php (or any other *.php files) are removed from the generated URL. It's not the most elegant solution but it will work for majority of people this affects.
